### PR TITLE
Implement webauthn-extensions.

### DIFF
--- a/webext/add-on/background.js
+++ b/webext/add-on/background.js
@@ -78,6 +78,39 @@ function serializeRequest(options) {
       cred.id = serializeBytes(cred.id);
     }
   }
+  if (clone.publicKey.extensions && clone.publicKey.extensions.prf) {
+    if (clone.publicKey.extensions.prf.eval) {
+      clone.publicKey.extensions.prf.eval.first = serializeBytes(clone.publicKey.extensions.prf.eval.first);
+      if (clone.publicKey.extensions.prf.eval.second) {
+        clone.publicKey.extensions.prf.eval.second = serializeBytes(clone.publicKey.extensions.prf.eval.second);
+      }
+    }
+    if (clone.publicKey.extensions.prf.evalByCredential) {
+      const evalByCredential = clone.publicKey.extensions.prf.evalByCredential;
+
+      // Iterate over all credentialIDs, serialize the first/second bytebuffer and replace the original evalByCredential map
+      const result = {};
+      for (const credId in evalByCredentialData) {
+        const prfValue = evalByCredentialData[credId];
+
+        if (prfValue && prfValue.first) {
+          const newPrfValue = {
+              first: serializeBytes(prfValue.first)
+          };
+
+          if (prfValue.second) {
+              newPrfValue.second = serializeBytes(prfValue.second);
+          }
+          result[credId] = newPrfValue;
+        };
+      }
+      clone.publicKey.extensions.prf.evalByCredential = result;
+    }
+
+    if (clone.publicKey.extensions && clone.publicKey.extensions.credBlob) {
+      clone.publicKey.extensions.credBlob = serializeBytes(clone.publicKey.extensions.credBlob);
+    }
+  }
   return clone
 }
 

--- a/webext/add-on/manifest.json
+++ b/webext/add-on/manifest.json
@@ -1,5 +1,4 @@
 {
-
   "description": "Linux WebAuthn Desktop Portal Shim",
   "manifest_version": 3,
   "name": "WebAuthn Portal",
@@ -20,7 +19,7 @@
   },
   "content_scripts": [
     {
-        "matches": ["https://webauthn.io/*"],
+        "matches": ["https://webauthn.io/*", "https://demo.yubico.com/*"],
         "js": ["content.js"],
         "run_at": "document_start"
     }
@@ -31,5 +30,4 @@
   },
 
   "permissions": ["nativeMessaging"]
-
 }

--- a/xyz-iinuwa-credential-manager-portal-gtk/Cargo.lock
+++ b/xyz-iinuwa-credential-manager-portal-gtk/Cargo.lock
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "libwebauthn"
 version = "0.1.2"
-source = "git+https://github.com/linux-credentials/libwebauthn?rev=24eb47113e2282ff31c53de3029928e914349559#24eb47113e2282ff31c53de3029928e914349559"
+source = "git+https://github.com/linux-credentials/libwebauthn?rev=dc23daed528f512f2bcb61fce9eb6b8ee74066e2#dc23daed528f512f2bcb61fce9eb6b8ee74066e2"
 dependencies = [
  "aes",
  "async-trait",

--- a/xyz-iinuwa-credential-manager-portal-gtk/Cargo.toml
+++ b/xyz-iinuwa-credential-manager-portal-gtk/Cargo.toml
@@ -16,10 +16,11 @@ openssl = "0.10.72"
 ring = "0.17.14"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+# serde_cbor = "0.11.1"
 tracing = "0.1.41"
 tracing-subscriber = "0.3"
 zbus = "5.5.0"
-libwebauthn = { git = "https://github.com/linux-credentials/libwebauthn", rev = "24eb47113e2282ff31c53de3029928e914349559" }
+libwebauthn = { git = "https://github.com/linux-credentials/libwebauthn", rev = "dc23daed528f512f2bcb61fce9eb6b8ee74066e2" }
 async-trait = "0.1.88"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 

--- a/xyz-iinuwa-credential-manager-portal-gtk/src/platform_authenticator/store.rs
+++ b/xyz-iinuwa-credential-manager-portal-gtk/src/platform_authenticator/store.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use base64::{self, engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use ring::rand::{self, SecureRandom};
 
-use crate::webauthn::{CredentialDescriptor, Error, RelyingParty};
+use crate::webauthn::Error;
 static mut CRED_DIR: String = String::new();
 
 pub(crate) fn initialize() {


### PR DESCRIPTION
Implement various extensions that are now supported by libwebauthn.

I also moved some structs that are only needed for the platform-authenticator there, as most serializing is now done by libwebauthn and there is no need to have those struct definitions there anymore.

This is still not perfect, as I don't have _all_ the required checks that the platform is supposed to do in there, yet (e.g. the RP sending A and B, if only one or the other is officially allowed. Right now, I only ignore the irrelevant requests instead of erroring out).