### PR TITLE
Fix parsing of some MakeCredentialOptions

### DIFF
--- a/webext/add-on/background.js
+++ b/webext/add-on/background.js
@@ -72,8 +72,8 @@ function serializeRequest(options) {
   if (clone.publicKey.user) {
     clone.publicKey.user.id = serializeBytes(clone.publicKey.user.id)
   }
-  if (clone.publicKey.excludedCredentials) {
-    for (const cred in clone.publicKey.excludedCredentials) {
+  if (clone.publicKey.excludeCredentials) {
+    for (const cred of clone.publicKey.excludeCredentials) {
       cred.id = serializeBytes(cred.id)
     }
   }

--- a/xyz-iinuwa-credential-manager-portal-gtk/src/dbus.rs
+++ b/xyz-iinuwa-credential-manager-portal-gtk/src/dbus.rs
@@ -328,28 +328,30 @@ impl CreateCredentialRequest {
         let other_options =
             serde_json::from_str::<webauthn::MakeCredentialOptions>(&request_value.to_string())
                 .map_err(|_| webauthn::Error::Internal("Invalid request JSON".to_string()))?;
-        let (require_resident_key, user_verification) =
-            if let Some(authenticator_selection) = other_options.authenticator_selection {
-                let is_authenticator_storage_capable = true;
-                let require_resident_key = authenticator_selection.resident_key.map_or_else(
-                    || false,
-                    |r| r == "required" || (r == "preferred" && is_authenticator_storage_capable),
-                ); // fallback to authenticator_selection.require_resident_key == true for WebAuthn Level 1?
+        let (require_resident_key, user_verification) = if let Some(authenticator_selection) =
+            other_options.authenticator_selection
+        {
+            let is_authenticator_storage_capable = true;
+            let require_resident_key = authenticator_selection
+                .resident_key
+                .map(|r| r == "required" || (r == "preferred" && is_authenticator_storage_capable))
+                .or(authenticator_selection.require_resident_key) // fallback to authenticator_selection.require_resident_key == true for WebAuthn Level 1
+                .unwrap_or_default();
 
-                let user_verification = authenticator_selection
-                    .user_verification
-                    .map(|uv| match uv.as_ref() {
-                        "required" => UserVerificationRequirement::Required,
-                        "preferred" => UserVerificationRequirement::Preferred,
-                        "discouraged" => UserVerificationRequirement::Discouraged,
-                        _ => todo!("This should be fixed in the future"),
-                    })
-                    .unwrap_or(UserVerificationRequirement::Preferred);
+            let user_verification = authenticator_selection
+                .user_verification
+                .map(|uv| match uv.as_ref() {
+                    "required" => UserVerificationRequirement::Required,
+                    "preferred" => UserVerificationRequirement::Preferred,
+                    "discouraged" => UserVerificationRequirement::Discouraged,
+                    _ => todo!("This should be fixed in the future"),
+                })
+                .unwrap_or(UserVerificationRequirement::Preferred);
 
-                (require_resident_key, user_verification)
-            } else {
-                (false, UserVerificationRequirement::Preferred)
-            };
+            (require_resident_key, user_verification)
+        } else {
+            (false, UserVerificationRequirement::Preferred)
+        };
         let extensions = if let Some(incoming_extensions) = other_options.extensions {
             let extensions = MakeCredentialsRequestExtensions {
                 cred_props: incoming_extensions.cred_props,

--- a/xyz-iinuwa-credential-manager-portal-gtk/src/webauthn.rs
+++ b/xyz-iinuwa-credential-manager-portal-gtk/src/webauthn.rs
@@ -11,7 +11,6 @@ use libwebauthn::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::debug;
-use zbus::zvariant::{DeserializeDict, Type};
 
 use crate::cose::{CoseKeyAlgorithmIdentifier, CoseKeyType};
 
@@ -75,7 +74,7 @@ pub(crate) struct MakeCredentialOptions {
     #[serde(deserialize_with = "crate::serde::duration::from_opt_ms")]
     #[serde(default)]
     pub timeout: Option<Duration>,
-    #[serde(rename = "excludedCredentials")]
+    #[serde(rename = "excludeCredentials")]
     pub excluded_credentials: Option<Vec<CredentialDescriptor>>,
     #[serde(rename = "authenticatorSelection")]
     pub authenticator_selection: Option<AuthenticatorSelectionCriteria>,
@@ -197,8 +196,7 @@ pub(crate) struct GetCredentialExtensions {
     pub prf: Option<Prf>,
 }
 
-#[derive(Debug, Deserialize, Type)]
-#[zvariant(signature = "dict")]
+#[derive(Debug, Deserialize)]
 /// https://www.w3.org/TR/webauthn-3/#dictionary-credential-descriptor
 pub(crate) struct CredentialDescriptor {
     /// Type of the public key credential the caller is referring to.
@@ -250,8 +248,7 @@ impl TryFrom<CredentialDescriptor> for Ctap2PublicKeyCredentialDescriptor {
     }
 }
 
-#[derive(Debug, DeserializeDict, Type)]
-#[zvariant(signature = "dict")]
+#[derive(Debug, Deserialize)]
 /// https://www.w3.org/TR/webauthn-3/#dictionary-authenticatorSelection
 pub(crate) struct AuthenticatorSelectionCriteria {
     // /// https://www.w3.org/TR/webauthn-3/#enum-attachment
@@ -259,15 +256,16 @@ pub(crate) struct AuthenticatorSelectionCriteria {
     // pub authenticator_attachment: Option<String>,
     //
     /// https://www.w3.org/TR/webauthn-3/#enum-residentKeyRequirement
-    #[zvariant(rename = "residentKey")]
+    #[serde(rename = "residentKey")]
     pub resident_key: Option<String>,
 
     // Implied by resident_key == "required", deprecated in webauthn
     // https://www.w3.org/TR/webauthn-3/#enum-residentKeyRequirement
-    // #[zvariant(rename = "requireResidentKey")]
-    // require_resident_key: Option<bool>,
+    #[serde(rename = "requireResidentKey")]
+    pub require_resident_key: Option<bool>,
+
     /// https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement
-    #[zvariant(rename = "userVerification")]
+    #[serde(rename = "userVerification")]
     pub user_verification: Option<String>,
 }
 


### PR DESCRIPTION
Various MakeCredential options didn't end up in libwebauthn, because of typos or wrong parsing. I also added the `require_resident_key`-fallback that was already hinted at in the comments.