### PR TITLE
Don't error out because of UxUpdate messages

### DIFF
--- a/xyz-iinuwa-credential-manager-portal-gtk/src/credential_service/usb.rs
+++ b/xyz-iinuwa-credential-manager-portal-gtk/src/credential_service/usb.rs
@@ -145,15 +145,6 @@ impl InProcessUsbHandler {
                         None => Err("Channel disconnected".to_string()),
                     }
                 }
-                UsbStateInternal::NeedsPin {
-                    attempts_left: Some(attempts_left),
-                    ..
-                } if attempts_left <= 1 => Err("No more USB attempts left".to_string()),
-                UsbStateInternal::NeedsUserVerification {
-                    attempts_left: Some(attempts_left),
-                } if attempts_left <= 1 => {
-                    Err("No more on-device user device attempts left".to_string())
-                }
                 UsbStateInternal::NeedsPin { .. }
                 | UsbStateInternal::NeedsUserVerification { .. }
                 | UsbStateInternal::NeedsUserPresence => match signal_rx.recv().await {


### PR DESCRIPTION
The `UsbStateInternal::NeedsUserVerification`-case prevented the fallback from fingerprints to PINs, in case UV got blocked by using the wrong finger too often.
In general, I don't think we should error out because of `UxUpdates` at all, as libwebauthn should error out properly in case of actual errors in the actual function call (not via the updates channel).
With this patch, I'm able to fall back to entering PINs after UV got blocked. However, once PINs get blocked also, the UI doesn't reflect that, but I think this is a general issue right now with propagating/displaying errors of any kind. 
Sadly, I didn't have the time to add a fix for that to this PR, too.