### PR TITLE
User cancellation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
             "args": [],
             "env": {
                 "GSETTINGS_SCHEMA_DIR": "${workspaceFolder}/build/credentialsd-ui/data",
-                "RUST_LOG": "creds_ui=debug,zbus::trace,zbus::object_server::debug"
+                "RUST_LOG": "credentialsd_ui=debug,zbus::trace,zbus::object_server::debug"
             },
             "sourceLanguages": ["rust"],
             "cwd": "${workspaceFolder}",

--- a/credentialsd-common/src/client.rs
+++ b/credentialsd-common/src/client.rs
@@ -2,7 +2,10 @@ use std::pin::Pin;
 
 use futures_lite::Stream;
 
-use crate::model::{BackgroundEvent, Device};
+use crate::{
+    model::{BackgroundEvent, Device},
+    server::RequestId,
+};
 
 /// Used for communication from trusted UI to credential service
 pub trait FlowController {
@@ -22,4 +25,5 @@ pub trait FlowController {
         &self,
         credential_id: String,
     ) -> impl Future<Output = Result<(), ()>> + Send;
+    fn cancel_request(&self, request_id: RequestId) -> impl Future<Output = Result<(), ()>> + Send;
 }

--- a/credentialsd-common/src/model.rs
+++ b/credentialsd-common/src/model.rs
@@ -188,6 +188,7 @@ pub enum ViewUpdate {
     HybridConnected,
 
     Completed,
+    Cancelled,
     Failed(String),
 }
 

--- a/credentialsd-common/src/server.rs
+++ b/credentialsd-common/src/server.rs
@@ -33,6 +33,7 @@ impl TryFrom<BackgroundEvent> for crate::model::BackgroundEvent {
     }
 }
 
+// TODO: this can be changed to infallible From
 impl TryFrom<crate::model::BackgroundEvent> for BackgroundEvent {
     type Error = zvariant::Error;
     fn try_from(value: crate::model::BackgroundEvent) -> Result<Self, Self::Error> {
@@ -326,6 +327,9 @@ impl From<HybridState> for Value<'_> {
         Value::from(fields)
     }
 }
+
+/// Identifier for a request to be used for cancellation.
+pub type RequestId = u32;
 
 #[derive(Serialize, Deserialize, Type)]
 pub enum ServiceError {
@@ -625,6 +629,7 @@ impl From<UsbState> for Value<'_> {
 #[derive(Serialize, Deserialize, Type)]
 pub struct ViewRequest {
     pub operation: Operation,
+    pub id: RequestId,
 }
 
 fn value_to_owned(value: &Value<'_>) -> OwnedValue {

--- a/credentialsd-common/src/server.rs
+++ b/credentialsd-common/src/server.rs
@@ -33,11 +33,9 @@ impl TryFrom<BackgroundEvent> for crate::model::BackgroundEvent {
     }
 }
 
-// TODO: this can be changed to infallible From
-impl TryFrom<crate::model::BackgroundEvent> for BackgroundEvent {
-    type Error = zvariant::Error;
-    fn try_from(value: crate::model::BackgroundEvent) -> Result<Self, Self::Error> {
-        let event = match value {
+impl From<crate::model::BackgroundEvent> for BackgroundEvent {
+    fn from(value: crate::model::BackgroundEvent) -> Self {
+        match value {
             crate::model::BackgroundEvent::HybridQrStateChanged(state) => {
                 let state: HybridState = state.into();
                 let value = Value::new(state)
@@ -53,8 +51,7 @@ impl TryFrom<crate::model::BackgroundEvent> for BackgroundEvent {
 
                 BackgroundEvent::UsbStateChanged(value)
             }
-        };
-        Ok(event)
+        }
     }
 }
 

--- a/credentialsd-ui/src/client.rs
+++ b/credentialsd-ui/src/client.rs
@@ -1,5 +1,5 @@
 use async_std::stream::Stream;
-use credentialsd_common::client::FlowController;
+use credentialsd_common::{client::FlowController, server::RequestId};
 use futures_lite::StreamExt;
 use zbus::{Connection, zvariant};
 
@@ -100,5 +100,18 @@ impl FlowController for DbusCredentialClient {
             .select_credential(credential_id)
             .await
             .map_err(|err| tracing::error!("Failed to select credential: {err}"))
+    }
+
+    async fn cancel_request(&self, request_id: RequestId) -> Result<(), ()> {
+        if self
+            .proxy()
+            .await?
+            .cancel_request(request_id)
+            .await
+            .is_err()
+        {
+            tracing::warn!("Failed to cancel request {request_id}");
+        }
+        Ok(())
     }
 }

--- a/credentialsd-ui/src/gui/view_model/gtk/application.rs
+++ b/credentialsd-ui/src/gui/view_model/gtk/application.rs
@@ -11,6 +11,8 @@ use crate::config::{APP_ID, PKGDATADIR, PROFILE, VERSION};
 use crate::gui::view_model::{ViewEvent, ViewUpdate};
 
 mod imp {
+    use crate::gui::view_model::gtk::ModelState;
+
     use super::*;
     use glib::{WeakRef, clone};
     use std::{
@@ -62,6 +64,20 @@ mod imp {
                             // Wait to show confirmation before closing.
                             async_std::task::sleep(Duration::from_millis(500)).await;
                             gtk::prelude::WidgetExt::activate_action(&window2, "window.close", None)
+                                .unwrap()
+                        }
+                    ));
+                }
+            });
+            let window3 = window.clone();
+            // TODO: merge these state callbacks into a single function
+            vm2.clone().connect_state_notify(move |vm| {
+                if let ModelState::Cancelled = vm.state() {
+                    glib::spawn_future_local(clone!(
+                        #[weak]
+                        window3,
+                        async move {
+                            gtk::prelude::WidgetExt::activate_action(&window3, "window.close", None)
                                 .unwrap()
                         }
                     ));

--- a/credentialsd-ui/src/gui/view_model/gtk/mod.rs
+++ b/credentialsd-ui/src/gui/view_model/gtk/mod.rs
@@ -51,6 +51,9 @@ mod imp {
         #[property(get, set)]
         pub prompt: RefCell<String>,
 
+        #[property(get, set, builder(ModelState::Pending))]
+        pub state: RefCell<ModelState>,
+
         #[property(get, set)]
         pub completed: RefCell<bool>,
 
@@ -189,10 +192,14 @@ impl ViewModel {
                                     view_model.set_failed(true);
                                     view_model.set_prompt(error_msg);
                                 }
+                                ViewUpdate::Cancelled => {
+                                    view_model.set_state(ModelState::Cancelled)
+                                }
                             }
                         }
                         Err(e) => {
                             debug!("ViewModel event listener interrupted: {}", e);
+                            view_model.set_state(ModelState::Cancelled);
                             break;
                         }
                     }
@@ -360,4 +367,14 @@ pub fn start_gtk_app(
 
     let app = ExampleApplication::new(tx_event, rx_update);
     app.run();
+}
+
+#[derive(Clone, Copy, Debug, Default, glib::Enum)]
+#[enum_type(name = "ModelState")]
+pub enum ModelState {
+    #[default]
+    Pending,
+    Completed,
+    Failed,
+    Cancelled,
 }

--- a/credentialsd-ui/src/gui/view_model/gtk/window.rs
+++ b/credentialsd-ui/src/gui/view_model/gtk/window.rs
@@ -17,6 +17,8 @@ use crate::gui::view_model::Transport;
 mod imp {
     use gtk::Picture;
 
+    use crate::gui::view_model::ViewEvent;
+
     use super::*;
 
     #[derive(Debug, Properties, gtk::CompositeTemplate)]
@@ -106,6 +108,17 @@ mod imp {
     impl WindowImpl for ExampleApplicationWindow {
         // Save window state on delete event
         fn close_request(&self) -> glib::Propagation {
+            if let Some(vm) = self.view_model.borrow().as_ref() {
+                if vm
+                    .get_sender()
+                    .send_blocking(ViewEvent::UserCancelled)
+                    .is_err()
+                {
+                    tracing::warn!(
+                        "Failed to notify the backend service that the user cancelled the request."
+                    );
+                };
+            }
             if let Err(err) = self.obj().save_window_size() {
                 tracing::warn!("Failed to save window state, {}", &err);
             }

--- a/credentialsd-ui/src/gui/view_model/mod.rs
+++ b/credentialsd-ui/src/gui/view_model/mod.rs
@@ -174,6 +174,9 @@ impl<F: FlowController + Send> ViewModel<F> {
                             .unwrap();
                     }
                 }
+                Event::View(ViewEvent::UserCancelled) => {
+                    break;
+                }
 
                 Event::Background(BackgroundEvent::UsbStateChanged(state)) => {
                     match state {
@@ -269,13 +272,18 @@ impl<F: FlowController + Send> ViewModel<F> {
                         }
                         HybridState::UserCancelled => {
                             self.hybrid_qr_code_data = None;
+                            break;
                         }
                         HybridState::Failed => {
                             self.hybrid_qr_code_data = None;
                             self.tx_update.send(ViewUpdate::Failed(String::from("Something went wrong. Try again later or use a different authenticator."))).await.unwrap();
                         }
                     };
-                }
+                } /*
+                  Event::Background(BackgroundEvent::RequestCancelled(request_id)) => {
+                      break;
+                  }
+                  */
             };
         }
     }
@@ -287,6 +295,7 @@ pub enum ViewEvent {
     DeviceSelected(String),
     CredentialSelected(String),
     UsbPinEntered(String),
+    UserCancelled,
 }
 
 pub enum Event {

--- a/credentialsd/Cargo.lock
+++ b/credentialsd/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "gio",
  "libwebauthn",
  "openssl",
+ "rand 0.9.2",
  "ring",
  "rustls",
  "serde",
@@ -2098,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -2966,7 +2967,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/credentialsd/Cargo.toml
+++ b/credentialsd/Cargo.toml
@@ -16,6 +16,7 @@ credentialsd-common = { path = "../credentialsd-common" }
 futures-lite = "2.6.0"
 libwebauthn = "~0.2.2"
 openssl = "0.10.72"
+rand = "0.9.2"
 ring = "0.17.14"
 rustls = { version = "0.23.27", default-features = false, features = ["std", "tls12", "ring", "log", "logging", "prefer-post-quantum"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/credentialsd/src/dbus/flow_control.rs
+++ b/credentialsd/src/dbus/flow_control.rs
@@ -7,7 +7,7 @@ use std::{collections::VecDeque, fmt::Debug, sync::Arc};
 use credentialsd_common::model::{
     CredentialRequest, CredentialResponse, Error as CredentialServiceError, WebAuthnError,
 };
-use credentialsd_common::server::{BackgroundEvent, Device};
+use credentialsd_common::server::{BackgroundEvent, Device, RequestId};
 use futures_lite::StreamExt;
 use tokio::sync::oneshot;
 use tokio::{
@@ -254,6 +254,11 @@ where
         Ok(())
     }
 
+    async fn cancel_request(&self, request_id: RequestId) -> fdo::Result<()> {
+        self.svc.lock().await.cancel_request(request_id).await;
+        Ok(())
+    }
+
     #[zbus(signal)]
     async fn state_changed(
         emitter: &SignalEmitter<'_>,
@@ -334,6 +339,7 @@ pub mod test {
     use credentialsd_common::{
         client::FlowController,
         model::{BackgroundEvent, Device},
+        server::RequestId,
     };
     use futures_lite::{Stream, StreamExt};
     use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex};
@@ -450,8 +456,12 @@ pub mod test {
             }
         }
 
-        async fn select_credential(&self, credential_id: String) -> Result<(), ()> {
+        async fn select_credential(&self, _credential_id: String) -> Result<(), ()> {
             todo!();
+        }
+
+        async fn cancel_request(&self, _request_id: RequestId) -> Result<(), ()> {
+            todo!()
         }
     }
 
@@ -523,12 +533,12 @@ pub mod test {
                         DummyFlowResponse::GetDevices(rsp)
                     }
                     DummyFlowRequest::GetHybridCredential => {
-                        let rsp = self.get_hybrid_credential().await;
+                        self.get_hybrid_credential().await.unwrap();
                         DummyFlowResponse::GetHybridCredential
                     }
 
                     DummyFlowRequest::GetUsbCredential => {
-                        let rsp = self.get_usb_credential().await;
+                        self.get_usb_credential().await.unwrap();
                         DummyFlowResponse::GetUsbCredential
                     }
                     DummyFlowRequest::InitStream => {
@@ -656,7 +666,11 @@ pub mod test {
             Ok(())
         }
 
-        async fn select_credential(&self, credential_id: String) -> Result<(), ()> {
+        async fn select_credential(&self, _credential_id: String) -> Result<(), ()> {
+            todo!();
+        }
+
+        async fn cancel_request(&self, _request_id: RequestId) -> Result<(), ()> {
             todo!();
         }
     }

--- a/credentialsd/src/dbus/ui_control.rs
+++ b/credentialsd/src/dbus/ui_control.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 use zbus::{fdo, proxy, Connection};
 
-use credentialsd_common::server::ViewRequest;
+use credentialsd_common::server::{RequestId, ViewRequest};
 
 use crate::credential_service::UiController;
 
@@ -16,6 +16,7 @@ use crate::credential_service::UiController;
 )]
 trait UiControlService {
     fn launch_ui(&self, request: ViewRequest) -> fdo::Result<()>;
+    fn cancel_request(&self, request_id: RequestId) -> fdo::Result<()>;
 }
 
 #[derive(Debug)]
@@ -181,7 +182,7 @@ pub mod test {
                 .unwrap();
         }
 
-        pub async fn select_credential(&self, cred_id: String) {
+        pub async fn select_credential(&self, _cred_id: String) {
             tracing::debug!(
                 target: "DummyUiServer",
                 "Received select_credential() request"


### PR DESCRIPTION
Signals to the cred service that the UI is closing when:
- the close button is clicked
- the keyboard shortcut (Ctrl+Q) is pressed
- the window manager closes the window

Cancellation should be idempotent, so cancellations for the same request ID should not cause any problems